### PR TITLE
Adds @Input() similar to typescript API

### DIFF
--- a/src/main/scala/angulate2/Input.scala
+++ b/src/main/scala/angulate2/Input.scala
@@ -1,0 +1,7 @@
+package angulate2
+
+import scala.annotation.StaticAnnotation
+
+class Input() extends StaticAnnotation {
+  def this(externalName: String) = this()
+}


### PR DESCRIPTION
This allows you to write `@Input()` in much the same way as the typescript API:

```
@Component(
  ...
  inputs = js.Array("the-hero:hero")
)
class TheComponent {
  var hero: js.UndefOr[Hero] = js.undefined
}
```

can now be written as:

```
@Component(
  ...
)
class TheComponent {
  @Input("the-hero")
  var hero: js.UndefOr[Hero] = js.undefined
}
```

`@Input()` works with no parameter as well and if you explicitly specify the `inputs` parameter it will merge the annotation inputs with the parameter passed in.