### PR TITLE
fixed children routes to be a jsArray instead of a single route

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val rxjsVersion = "0.0.1"
 
 lazy val commonSettings = Seq(
   organization := "de.surfice",
-  version := "0.0.2",
+  version := "0.0.2.1-SNAPSHOT",
   scalaVersion := "2.11.8",
   scalacOptions ++= Seq("-deprecation","-unchecked","-feature","-language:implicitConversions","-Xlint"),
   autoCompilerPlugins := true,

--- a/src/main/scala/angulate2/router/config.scala
+++ b/src/main/scala/angulate2/router/config.scala
@@ -33,5 +33,5 @@ case class Route(path: js.UndefOr[String] = js.undefined,
                  canLoad: js.UndefOr[js.Array[js.Any]] = js.undefined,
                  data: js.UndefOr[Data] = js.undefined,
                  resolveData: js.UndefOr[ResolveData] = js.undefined,
-                 children: js.UndefOr[Route] = js.undefined,
+                 children: js.UndefOr[Routes] = js.undefined,
                  loadChildren: js.UndefOr[LoadChildren] = js.undefined)


### PR DESCRIPTION
Simple change to match the expected javascript value for children routes of a route.